### PR TITLE
fix: email input and social icon navigation in WELCOME modal

### DIFF
--- a/src/components/modals/EmailRegistrationModal.tsx
+++ b/src/components/modals/EmailRegistrationModal.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/navigation";
 import { FC } from "react";
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import { SocialIcon } from "react-social-icons";
 import { z } from "zod";
 
@@ -27,7 +27,7 @@ const EmailRegistrationModal: FC<ModalProps> = ({ onClose, ...props }) => {
   const { address } = useSorobanReact();
   const router = useRouter();
   const {
-    register,
+    control,
     handleSubmit,
     formState: { errors, isSubmitting },
   } = useForm<EmailRegistrationFormData>({
@@ -111,7 +111,18 @@ const EmailRegistrationModal: FC<ModalProps> = ({ onClose, ...props }) => {
           <form onSubmit={handleSubmit(onSubmit)} style={{ width: "100%" }}>
             <Flex w="full" direction="column" align="center" gap={4}>
               <Flex w="full" direction="column" gap={2}>
-                <Input placeholder="Email" {...register("email")} />
+                <Controller
+                  name="email"
+                  control={control}
+                  render={({ field }) => (
+                    <Input
+                      placeholder="Email"
+                      value={field.value}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                    />
+                  )}
+                />
                 {errors.email && (
                   <Text color="red.500" fontSize="sm">
                     {errors.email.message}
@@ -134,13 +145,13 @@ const EmailRegistrationModal: FC<ModalProps> = ({ onClose, ...props }) => {
           </Text>
           <HStack spaceX={6} justify="center">
             <Box cursor="pointer" onClick={() => handleShare("facebook")}>
-              <SocialIcon network="facebook" />
+              <SocialIcon network="facebook" url="" />
             </Box>
             <Box cursor="pointer" onClick={() => handleShare("whatsapp")}>
-              <SocialIcon network="whatsapp" />
+              <SocialIcon network="whatsapp" url="" />
             </Box>
             <Box cursor="pointer" onClick={() => handleShare("x")}>
-              <SocialIcon network="x" />
+              <SocialIcon network="x" url="" />
             </Box>
           </HStack>
         </Flex>


### PR DESCRIPTION
## Problem Statement

Two bugs in the WELCOME (Email Registration) modal reported in PR #42 review by Nathan:

1. **Email input not registering keystrokes** — `react-hook-form`'s `register` relies on a `RefCallback` attached to the native `<input>` DOM element. With Chakra v3's `Input = withContext(Field.Input)` wrapper chain (`withContext` → `chakra(Field.Input)` → `ark.input`), the ref doesn't resolve to the native `<input>` reliably. This means react-hook-form never registers the field, and typing does nothing.

2. **Social icons causing modal to break** — `SocialIcon` renders real `<a href="https://facebook.com">` anchor tags. Clicking them fires BOTH our `handleShare` (opens new window) AND the anchor's own navigation. Inside the Chakra v3 Dialog this causes the focus trap to break, the close-on-interact-outside to fire unexpectedly, and the input to lose registration.

## What Changed

| File | Change |
|------|--------|
| `src/components/modals/EmailRegistrationModal.tsx` | Replace `register("email")` with `Controller` component; add `url=""` to all `SocialIcon` instances |

## Why

- **`Controller`** uses controlled component binding (`value`/`onChange`/`onBlur`) instead of ref-based registration, so it works reliably regardless of how many wrapper layers sit between react-hook-form and the native `<input>`
- **`url=""`** on `SocialIcon` prevents the component from rendering an anchor tag with a real `href`, eliminating the competing navigation that breaks the modal

## How

**Email input fix:**
```diff
- <Input placeholder="Email" {...register("email")} />
+ <Controller
+   name="email"
+   control={control}
+   render={({ field }) => (
+     <Input
+       placeholder="Email"
+       value={field.value}
+       onChange={field.onChange}
+       onBlur={field.onBlur}
+     />
+   )}
+ />
```

**Social icon fix:**
```diff
- <SocialIcon network="facebook" />
+ <SocialIcon network="facebook" url="" />
```

## Testing Steps

1. Connect wallet → click **Rewards** → WELCOME modal opens
2. Click the **email input field** → should gain focus
3. **Type an email address** → characters should appear in the input
4. Click **Register email** → should submit successfully (no "invalid email" error from empty field)
5. Click **Facebook icon** → should open Facebook share dialog in new tab, modal stays open and functional
6. Click **WhatsApp icon** → should open WhatsApp share in new tab, modal stays intact
7. Click **X icon** → should open X/Twitter compose in new tab, modal stays intact
8. After clicking any social icon, **email input should still be typeable** (focus trap not broken)